### PR TITLE
Improve query heuristics

### DIFF
--- a/cmd/sea/main.go
+++ b/cmd/sea/main.go
@@ -1,5 +1,85 @@
 package main
 
+import (
+	"bytes"
+	"embed"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+
+	"github.com/pelletier/go-toml/v2"
+)
+
+// Config represents the TOML configuration structure.
+type Config struct {
+	Listen         int           `toml:"listen"`
+	ServerName     string        `toml:"server_name"`
+	CustomKeywords []KeywordRule `toml:"custom_keywords"`
+}
+
+// KeywordRule maps a phrase to a destination.
+type KeywordRule struct {
+	Phrase string `toml:"phrase"`
+	Dest   string `toml:"dest"`
+}
+
+//go:embed nginx.conf.tmpl
+var templateFS embed.FS
+
 func main() {
-	println("Hello, world!")
+	var cfgPath string
+	flag.StringVar(&cfgPath, "config", "config.toml", "path to TOML configuration")
+	flag.Parse()
+
+	cfg, err := loadConfig(cfgPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error loading config: %v\n", err)
+		os.Exit(1)
+	}
+
+	out, err := generateNginx(cfg)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error generating nginx config: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Print(out)
+}
+
+func loadConfig(path string) (Config, error) {
+	cfg := Config{Listen: 80, ServerName: "search.local"}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return cfg, nil
+		}
+		return cfg, err
+	}
+	if err := toml.Unmarshal(data, &cfg); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+// generateNginx assembles the nginx configuration using heuristics
+// and any custom keyword rules from the configuration file.
+func generateNginx(cfg Config) (string, error) {
+	tmpl, err := template.New("nginx.conf.tmpl").Funcs(template.FuncMap{
+		"escape": escapeSpace,
+	}).ParseFS(templateFS, "nginx.conf.tmpl")
+	if err != nil {
+		return "", err
+	}
+
+	var b bytes.Buffer
+	if err := tmpl.Execute(&b, cfg); err != nil {
+		return "", err
+	}
+	return b.String(), nil
+}
+
+func escapeSpace(s string) string {
+	return strings.ReplaceAll(s, " ", "\\ ")
 }

--- a/cmd/sea/nginx.conf.tmpl
+++ b/cmd/sea/nginx.conf.tmpl
@@ -1,0 +1,30 @@
+map $arg_q $dest {
+    default google;
+    ~*(?i)^\s*how\s+to\b                chatgpt;
+    ~*(?i)^\s*what\s+is\b               chatgpt;
+    ~*(?i)^\s*(when|where|why)\b         chatgpt;
+    ~*(?i)^\s*who\s+(?:is|was)\b       wikipedia;
+    ~*(?i)\bpictures?\s+of\b            google_images;
+    ~*(?i)\bvs\b                        google;
+    ~*(?i)\bdownload\b                   google;
+    ~*(?i)\bwikipedia\b|\bwiki\b        wikipedia;
+{{- range .CustomKeywords }}
+    ~*(?i)^{{ escape .Phrase }}$                {{ .Dest }};
+{{- end }}
+}
+
+map $dest $target {
+    google        "https://www.google.com/search?q=$arg_q";
+    google_images "https://www.google.com/search?tbm=isch&q=$arg_q";
+    chatgpt       "https://chat.openai.com/?q=$arg_q";
+    wikipedia     "https://en.wikipedia.org/wiki/$arg_q";
+}
+
+server {
+    listen {{ .Listen }};
+    server_name {{ .ServerName }};
+
+    location / {
+        return 302 $target;
+    }
+}

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,18 @@
+listen = 80
+server_name = "search.local"
+
+[[custom_keywords]]
+phrase = "nginx"
+dest = "wikipedia"
+
+[[custom_keywords]]
+phrase = "New York"
+dest = "wikipedia"
+
+[[custom_keywords]]
+phrase = "openai"
+dest = "wikipedia"
+
+[[custom_keywords]]
+phrase = "cat pictures"
+dest = "google_images"

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/dense-analysis/sea
 
 go 1.22.2
+
+require github.com/pelletier/go-toml/v2 v2.2.4

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pelletier/go-toml/v2 v2.2.4 h1:mye9XuhQ6gvn5h28+VilKrrPoQVanw5PMw/TB0t5Ec4=
+github.com/pelletier/go-toml/v2 v2.2.4/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=


### PR DESCRIPTION
## Summary
- update config generation heuristics with nginx map
- add example custom keyword mapping
- switch to Go template for nginx output

## Testing
- `go vet ./...`
- `go build ./...`
- `go run ./cmd/sea/main.go | head`

------
https://chatgpt.com/codex/tasks/task_b_685308a27184832aab7bc84ca70070ad