### PR TITLE
Add CI with nginx validation and Go tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+---
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      NGINX_VERSION: latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Go Tests
+        run: go test ./...
+      - name: Cache nginx image
+        id: cache-nginx
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/nginx.tar
+          key: ${{ runner.os }}-nginx-${{ env.NGINX_VERSION }}
+      - name: Load nginx image from cache
+        if: steps.cache-nginx.outputs.cache-hit == 'true'
+        run: docker load -i ~/.cache/nginx.tar
+      - name: Pull nginx image
+        if: steps.cache-nginx.outputs.cache-hit != 'true'
+        run: |
+          docker pull "nginx:$NGINX_VERSION"
+          mkdir -p ~/.cache
+          docker save "nginx:$NGINX_VERSION" -o ~/.cache/nginx.tar
+      - name: Validate generated nginx config
+        run: |
+          go run ./cmd/sea/main.go > nginx.conf
+          docker run --rm \
+            -v "$PWD/nginx.conf:/etc/nginx/conf.d/default.conf:ro" \
+            "nginx:$NGINX_VERSION" \
+            nginx -t

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,10 @@
 name: CI
 
 on:
-  push:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build:

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,5 @@
+---
+extends: default
+rules:
+  # Allow `foo: "on"` and other commonly used values.
+  truthy: disable

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ to search providers based on the phrases used.
 
 You can run the main executable like so:
 
-```
+```sh
 go run ./cmd/sea/main.go
 ```
 
@@ -14,10 +14,16 @@ go run ./cmd/sea/main.go
 to get it. Commit `config.toml` as a default configuration people can override
 if they so choose.
 
+You can run Go tests like so:
+
+```sh
+go test ./...
+```
+
 You may validate that the nginx configuration works with the docker compose file
 like so:
 
-```
+```sh
 # Leave an nginx docker image running on port 57321
 docker compose up
 # Check a redirect. The hostname comes from `server_name` in `config.toml`

--- a/cmd/sea/main_test.go
+++ b/cmd/sea/main_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEscapeSpace(t *testing.T) {
+	got := escapeSpace("hello world")
+	if got != "hello\\ world" {
+		t.Errorf("expected 'hello\\\\ world', got %q", got)
+	}
+}
+
+func TestLoadConfig(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cfg.toml")
+	data := []byte(`listen = 8080
+server_name = "example.com"
+
+[[custom_keywords]]
+phrase = "foo bar"
+dest = "google"`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatalf("failed to write config: %v", err)
+	}
+	cfg, err := loadConfig(path)
+	if err != nil {
+		t.Fatalf("loadConfig returned error: %v", err)
+	}
+	if cfg.Listen != 8080 {
+		t.Errorf("expected listen 8080, got %d", cfg.Listen)
+	}
+	if cfg.ServerName != "example.com" {
+		t.Errorf("expected server name example.com, got %s", cfg.ServerName)
+	}
+	if len(cfg.CustomKeywords) != 1 {
+		t.Fatalf("expected 1 custom keyword, got %d", len(cfg.CustomKeywords))
+	}
+	if cfg.CustomKeywords[0].Phrase != "foo bar" || cfg.CustomKeywords[0].Dest != "google" {
+		t.Errorf("unexpected custom keyword %+v", cfg.CustomKeywords[0])
+	}
+}
+
+func TestGenerateNginx(t *testing.T) {
+	cfg := Config{Listen: 8080, ServerName: "example.com", CustomKeywords: []KeywordRule{{Phrase: "foo", Dest: "google"}}}
+	out, err := generateNginx(cfg)
+	if err != nil {
+		t.Fatalf("generateNginx returned error: %v", err)
+	}
+	if !strings.Contains(out, "server_name example.com;") {
+		t.Errorf("generated config missing server name: %s", out)
+	}
+	if !strings.Contains(out, "~*(?i)^foo$") {
+		t.Errorf("generated config missing custom rule: %s", out)
+	}
+}


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run Go tests and validate generated nginx config using an nginx Docker image with caching
- add basic unit tests for configuration generation

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_6853c048e81c832abb3da1bfcbea0df9