### PR TITLE
Fix map variable name collisions

### DIFF
--- a/cmd/sea/nginx.conf.tmpl
+++ b/cmd/sea/nginx.conf.tmpl
@@ -1,6 +1,6 @@
 # Map routes search queries to the appropriate backend.
 # Regex is evaluated once per request; enable `pcre_jit` for best speed.
-map $arg_q $dest {
+map $arg_q $sea_dest {
     # direct image search
     ~*(?i)\bpictures?\s+of\b                         google_images;
     # map and direction queries
@@ -35,7 +35,7 @@ map $arg_q $dest {
 }
 
 # Map engine names to full URL targets. Update this list in Go.
-map $dest $target {
+map $sea_dest $sea_target {
     chatgpt https://chatgpt.com/?q=$arg_q;
     google https://www.google.com/search?q=$arg_q;
     google_images https://www.google.com/search?tbm=isch&q=$arg_q;
@@ -59,7 +59,7 @@ server {
 {{- end }}
 
     location / {
-        return 302 $target;
+        return 302 $sea_target;
     }
 }
 {{ if .RedirectHTTP }}
@@ -81,7 +81,7 @@ server {
     server_name {{ .ServerName }};
 
     location / {
-        return 302 $target;
+        return 302 $sea_target;
     }
 }
 {{ end }}
@@ -92,7 +92,7 @@ server {
     server_name {{ .ServerName }};
 
     location / {
-        return 302 $target;
+        return 302 $sea_target;
     }
 }
 {{ end }}

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,6 +1,6 @@
 # Map routes search queries to the appropriate backend.
 # Regex is evaluated once per request; enable `pcre_jit` for best speed.
-map $arg_q $dest {
+map $arg_q $sea_dest {
     # direct image search
     ~*(?i)\bpictures?\s+of\b                         google_images;
     # map and direction queries
@@ -32,7 +32,7 @@ map $arg_q $dest {
 }
 
 # Map engine names to full URL targets. Update this list in Go.
-map $dest $target {
+map $sea_dest $sea_target {
     chatgpt https://chatgpt.com/?q=$arg_q;
     google https://www.google.com/search?q=$arg_q;
     google_images https://www.google.com/search?tbm=isch&q=$arg_q;
@@ -43,11 +43,11 @@ map $dest $target {
 
 server {
     listen 80;
+    listen [::]:80;
     server_name search.localhost;
 
     location / {
-        return 302 $target;
+        return 302 $sea_target;
     }
 }
-
 


### PR DESCRIPTION
## Summary
- use uniquely-named variables for nginx `map` blocks to avoid collisions
- regenerate `nginx.conf` with the new variable names

## Testing
- `go test ./...`
- `docker compose up -d` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_686c380c182c832ab160a40c8d4242ed