### PR TITLE
Add logging_enabled flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ vim config.toml
 go run cmd/sea/main.go > sea.conf
 ```
 
+Set `logging_enabled = false` in `config.toml` if you want to disable NGINX
+access and error logs for the server blocks.
+
 ### TLS / Let's Encrypt
 
 If you want to run SEA behind HTTPS using Certbot, set `listen_ssl`,

--- a/cmd/sea/main.go
+++ b/cmd/sea/main.go
@@ -21,6 +21,7 @@ type Config struct {
 	SSLCertificateKey string        `toml:"ssl_certificate_key"`
 	LetsEncrypt       bool          `toml:"letsencrypt"`
 	RedirectHTTP      bool          `toml:"redirect_http"`
+	LoggingEnabled    bool          `toml:"logging_enabled"`
 	CustomKeywords    []KeywordRule `toml:"custom_keywords"`
 }
 
@@ -61,9 +62,10 @@ func main() {
 
 func loadConfig(path string) (Config, error) {
 	cfg := Config{
-		Listen:     80,
-		ListenSSL:  0,
-		ServerName: "search.localhost",
+		Listen:         80,
+		ListenSSL:      0,
+		ServerName:     "search.localhost",
+		LoggingEnabled: true,
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/cmd/sea/main_test.go
+++ b/cmd/sea/main_test.go
@@ -23,6 +23,8 @@ server_name = "example.com"
 
 redirect_http = true
 
+logging_enabled = false
+
 ssl_certificate = "/tmp/full.pem"
 ssl_certificate_key = "/tmp/key.pem"
 letsencrypt = true
@@ -52,6 +54,9 @@ dest = "google"`)
 	if !cfg.LetsEncrypt {
 		t.Error("expected letsencrypt true")
 	}
+	if cfg.LoggingEnabled {
+		t.Error("expected logging_enabled false")
+	}
 	if cfg.ServerName != "example.com" {
 		t.Errorf("expected server name example.com, got %s", cfg.ServerName)
 	}
@@ -65,10 +70,11 @@ dest = "google"`)
 
 func TestGenerateNginx(t *testing.T) {
 	cfg := Config{
-		Listen:       8080,
-		ListenSSL:    8443,
-		ServerName:   "example.com",
-		RedirectHTTP: true,
+		Listen:         8080,
+		ListenSSL:      8443,
+		ServerName:     "example.com",
+		LoggingEnabled: false,
+		RedirectHTTP:   true,
 		CustomKeywords: []KeywordRule{{
 			Phrase: "foo",
 			Dest:   "google",
@@ -86,5 +92,11 @@ func TestGenerateNginx(t *testing.T) {
 	}
 	if !strings.Contains(out, "~*(?i)^foo$") {
 		t.Errorf("generated config missing custom rule: %s", out)
+	}
+	if !strings.Contains(out, "access_log off;") {
+		t.Errorf("generated config missing access log disable: %s", out)
+	}
+	if !strings.Contains(out, "error_log /dev/null  crit;") {
+		t.Errorf("generated config missing error log disable: %s", out)
 	}
 }

--- a/cmd/sea/nginx.conf.tmpl
+++ b/cmd/sea/nginx.conf.tmpl
@@ -48,6 +48,10 @@ server {
     listen {{ .ListenSSL }} ssl http2;
     listen [::]:{{ .ListenSSL }} ssl http2;
     server_name {{ .ServerName }};
+    {{- if not .LoggingEnabled }}
+    access_log off;
+    error_log /dev/null  crit;
+    {{- end }}
     keepalive_timeout 5;
 {{- if .SSLCertificate }}
     ssl_certificate {{ .SSLCertificate }};
@@ -71,6 +75,10 @@ server {
     listen {{ .Listen }};
     listen [::]:{{ .Listen }};
     server_name {{ .ServerName }};
+    {{- if not .LoggingEnabled }}
+    access_log off;
+    error_log /dev/null  crit;
+    {{- end }}
 
     return 404;
 }
@@ -79,6 +87,10 @@ server {
     listen {{ .Listen }};
     listen [::]:{{ .Listen }};
     server_name {{ .ServerName }};
+    {{- if not .LoggingEnabled }}
+    access_log off;
+    error_log /dev/null  crit;
+    {{- end }}
 
     location / {
         return 302 $sea_target;
@@ -90,6 +102,10 @@ server {
     listen {{ .Listen }};
     listen [::]:{{ .Listen }};
     server_name {{ .ServerName }};
+    {{- if not .LoggingEnabled }}
+    access_log off;
+    error_log /dev/null  crit;
+    {{- end }}
 
     location / {
         return 302 $sea_target;

--- a/config-example.toml
+++ b/config-example.toml
@@ -1,6 +1,7 @@
 listen = 80
 listen_ssl = 443
 server_name = "your.site"
+# logging_enabled = true
 # ssl_certificate = "/etc/letsencrypt/live/your.site/fullchain.pem"
 # ssl_certificate_key = "/etc/letsencrypt/live/your.site/privkey.pem"
 # letsencrypt = true


### PR DESCRIPTION
## Summary
- add a `logging_enabled` option in config
- allow disabling of access and error logs in the nginx template
- document the new option and provide an example
- test logging functionality and defaults

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_686cc2865d14832ab0c79d28f01f6561